### PR TITLE
Update cantaloupe.properties to enable logging by default

### DIFF
--- a/cantaloupe.properties
+++ b/cantaloupe.properties
@@ -628,6 +628,8 @@ redaction.enabled = false
 # LOGGING
 ###########################################################################
 
+log.file.path = /usr/local/fedora/server/logs
+
 #----------------------------------------
 # Application Log
 #----------------------------------------
@@ -635,16 +637,16 @@ redaction.enabled = false
 # `trace`, `debug`, `info`, `warn`, `error`, `all`, or `off`
 log.application.level = debug
 
-log.application.ConsoleAppender.enabled = true
+log.application.ConsoleAppender.enabled = false
 
 # N.B.: Don't enable FileAppender and RollingFileAppender simultaneously!
-log.application.FileAppender.enabled = false
-log.application.FileAppender.pathname = /usr/local/fedora/server/logs/application.log
+log.application.FileAppender.enabled = true
+log.application.FileAppender.pathname = ${log.file.path}/cantaloupe-application.log
 
 log.application.RollingFileAppender.enabled = false
-log.application.RollingFileAppender.pathname = /usr/local/fedora/server/logs/application.log
+log.application.RollingFileAppender.pathname = ${log.file.path}/cantaloupe-application.log
 log.application.RollingFileAppender.policy = TimeBasedRollingPolicy
-log.application.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = /usr/local/fedora/server/logs/application-%d{yyyy-MM-dd}.log
+log.application.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = ${log.file.path}/cantaloupe-application-%d{yyyy-MM-dd}.log
 log.application.RollingFileAppender.TimeBasedRollingPolicy.max_history = 30
 
 # See the "SyslogAppender" section for a list of facilities:
@@ -662,13 +664,13 @@ log.application.SyslogAppender.facility = LOCAL0
 # into a dedicated error log, which may make them easier to spot.
 
 # N.B.: Don't enable FileAppender and RollingFileAppender simultaneously!
-log.error.FileAppender.enabled = false
-log.error.FileAppender.pathname = /usr/local/fedora/server/logs/error.log
+log.error.FileAppender.enabled = true
+log.error.FileAppender.pathname = ${log.file.path}/cantaloupe-error.log
 
 log.error.RollingFileAppender.enabled = false
-log.error.RollingFileAppender.pathname = /usr/local/fedora/server/logs/error.log
+log.error.RollingFileAppender.pathname = ${log.file.path}/cantaloupe-error.log
 log.error.RollingFileAppender.policy = TimeBasedRollingPolicy
-log.error.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = /usr/local/fedora/server/logs/error-%d{yyyy-MM-dd}.log
+log.error.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = ${log.file.path}/cantaloupe-error-%d{yyyy-MM-dd}.log
 log.error.RollingFileAppender.TimeBasedRollingPolicy.max_history = 30
 
 #----------------------------------------
@@ -679,14 +681,14 @@ log.access.ConsoleAppender.enabled = false
 
 # N.B.: Don't enable FileAppender and RollingFileAppender simultaneously!
 log.access.FileAppender.enabled = false
-log.access.FileAppender.pathname = /usr/local/fedora/server/logs/access.log
+log.access.FileAppender.pathname = ${log.file.path}/cantaloupe-access.log
 
 # RollingFileAppender is an alternative to using something like
 # FileAppender + logrotate.
 log.access.RollingFileAppender.enabled = false
-log.access.RollingFileAppender.pathname = /usr/local/fedora/server/logs/access.log
+log.access.RollingFileAppender.pathname = ${log.file.path}/cantaloupe-access.log
 log.access.RollingFileAppender.policy = TimeBasedRollingPolicy
-log.access.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = /usr/local/fedora/server/logs/access-%d{yyyy-MM-dd}.log
+log.access.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = ${log.file.path}/cantaloupe-access-%d{yyyy-MM-dd}.log
 log.access.RollingFileAppender.TimeBasedRollingPolicy.max_history = 30
 
 # See the "SyslogAppender" section for a list of facilities:


### PR DESCRIPTION
I decided to go with FileAppender as we already have logrotated setup to rotate all files that end in .log in the logging dir we are writing to.