### PR TITLE
Adjusting TTL/Max Age configurations for cached images to something more sensible

### DIFF
--- a/cantaloupe.properties
+++ b/cantaloupe.properties
@@ -389,7 +389,7 @@ OpenJpegProcessor.path_to_binaries =
 # Whether to enable the response Cache-Control header.
 cache.client.enabled = true
 
-cache.client.max_age = 2592000
+cache.client.max_age = 3600
 cache.client.shared_max_age =
 cache.client.public = true
 cache.client.private = false
@@ -412,7 +412,7 @@ cache.server.source = FilesystemCache
 
 # Amount of time source cache content remains valid. Set to blank or 0
 # for forever.
-cache.server.source.ttl_seconds = 2592000
+cache.server.source.ttl_seconds = 3600
 
 # Enables the derivative (processed image) cache.
 cache.server.derivative.enabled = false
@@ -423,7 +423,7 @@ cache.server.derivative =
 
 # Amount of time derivative cache content remains valid. Set to blank or 0
 # for forever.
-cache.server.derivative.ttl_seconds = 2592000
+cache.server.derivative.ttl_seconds = 3600
 
 # Whether to use the Java heap as a "level 1" cache for image infos, either
 # independently or in front of a "level 2" derivative cache (if enabled).


### PR DESCRIPTION
The TTL for cached images was set way too high (720 hours) which resulted in ballooning cache file directories. I've changed this to something a little more sane (1 hour).

I wasn't sure if I should have changed Max Age for client-sided caching, but it made sense to me.