### PR TITLE
Suppress configuration key (boolean) which can not be overridden...

### DIFF
--- a/cantaloupe.properties
+++ b/cantaloupe.properties
@@ -461,7 +461,7 @@ cache.server.source = FilesystemCache
 cache.server.source.ttl_seconds = 3600
 
 # Enables the derivative (processed image) cache.
-cache.server.derivative.enabled = false
+#cache.server.derivative.enabled = false
 
 # Available values are `FilesystemCache`, `JdbcCache`, `RedisCache`,
 # `HeapCache`, `S3Cache`, and `AzureStorageCache`.


### PR DESCRIPTION
... and that we want to...

See https://github.com/cantaloupe-project/cantaloupe/issues/350

[`false` is the default for `cache.server.derivative.enabled`](https://github.com/cantaloupe-project/cantaloupe/blob/0dc0dec137da22ad8e37e7e22355ca360c729b98/src/main/java/edu/illinois/library/cantaloupe/cache/CacheFactory.java#L162), so avoid spec'ing it in the file.