### PR TITLE
SEC-2525: Allow for additional templating of the URL.

### DIFF
--- a/default_i8_delegates.rb
+++ b/default_i8_delegates.rb
@@ -17,7 +17,7 @@ if $sites_cache.nil?
   $semaphore.synchronize {
     # Avoid repopulating if populated in another thread...
     if $sites_cache.nil?
-      $sites_cache = CacheLib.safe_create :lru, $info['sitemap'].length
+      $sites_cache = CacheLib.safe_create :lru, ($info['sitemap'].length + $info['sites_cache_size'])
     end
   }
 end
@@ -165,7 +165,7 @@ class CustomDelegate
     # If...
     if _resource
       # ... we have something that appears to be an I8 resource, enforce auth...
-      $sites_cache.limit = $info['sitemap'].length
+      $sites_cache.limit = ($info['sitemap'].length + $info['sites_cache_size'])
       site_cache = $sites_cache.get(_site_id) {
         $logger.debug("Creating token bucket for #{_site_id}")
         # XXX: Implicit return to populate cache value.

--- a/default_i8_delegates.rb
+++ b/default_i8_delegates.rb
@@ -57,6 +57,12 @@ class CustomDelegate
     end
   end
 
+  # check if site_id is valid when validation regex is set
+  def _site_id_valid?
+    re = /#{$info.fetch('site_id_regex','^[a-zA-Z][a-zA-Z0-9_-]*$')}/
+    return re.match?(_site_id)
+  end
+
   # Build up the full URL to the resource.
   def _resource
     if _site_id and _suffix
@@ -70,6 +76,9 @@ class CustomDelegate
   # Override; allow the passing of additional headers for auth.
   def httpsource_resource_info(options = {})
     if _site_id
+      unless _site_id_valid?
+        return nil
+      end
       url = _resource
 
       $logger.debug("Site ID '#{_site_id}' resolved to '#{url}'.")
@@ -163,6 +172,10 @@ class CustomDelegate
   # Override; handle I8 resource auth.
   def pre_authorize(options = {})
     # If...
+    if _site_id and not _site_id_valid?
+      $logger.debug("Site ID '#{_site_id}' is invalid.")
+      return false
+    end
     if _resource
       # ... we have something that appears to be an I8 resource, enforce auth...
       $sites_cache.limit = ($info['sitemap'].length + $info['sites_cache_size'])

--- a/default_i8_delegates.rb
+++ b/default_i8_delegates.rb
@@ -60,7 +60,8 @@ class CustomDelegate
   # Build up the full URL to the resource.
   def _resource
     if _site_id and _suffix
-      $info['sitemap'].fetch(_site_id) % {
+      $info['sitemap'].fetch(_site_id, $info['modern_fallback']) % {
+        site_id: _site_id,
         suffix: Base64.decode64(_suffix),
       }
     end

--- a/info.yaml.example
+++ b/info.yaml.example
@@ -29,3 +29,8 @@ modern_fallback: ~
 sitemap:
     alpha: 'http://localhost/alpha/islandora/object/%{pid}/datastream/%{dsid}/view?token=%{token}'
     bravo: 'http://localhost/bravo/islandora/object/%{pid}/datastream/%{dsid}/view?token=%{token}'
+
+# 'sites_cache_size': Integer indicating the number of cache buckets for which to
+#   allow. Actual size is the sum of this value and count of entries in
+#   `sitemap`.
+sites_cache_size: 10

--- a/info.yaml.example
+++ b/info.yaml.example
@@ -34,3 +34,6 @@ sitemap:
 #   allow. Actual size is the sum of this value and count of entries in
 #   `sitemap`.
 sites_cache_size: 10
+
+# 'site_id_regex': Regex used to validate site IDs for modern installations.
+#site_id_regex: '^[a-zA-Z][a-zA-Z0-9_-]*$'

--- a/info.yaml.example
+++ b/info.yaml.example
@@ -12,6 +12,14 @@
 # 'fallback': The default URL template to use if nothing is matched in
 #   the 'sitemap' hash below. The (hard-coded) default is the same as below:
 fallback: 'http://localhost/islandora/object/%{pid}/datastream/%{dsid}/view?token=%{token}'
+
+# 'modern_fallback': The default URL template to use if nothing is match in the
+# 'sitemap' hash. Nil by default. Fill out with a string.
+# Available to be templated:
+# - suffix
+# - site_id
+modern_fallback: ~
+
 # 'sitemap': Hash of opaque site identifiers to related URL templates. This site
 #   identifier should be provided as a fourth value the tilde-separated IIIF
 #   identifier; for example, "the:pid~JP2~access_token~opaque_identifier".


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `modern_fallback` configuration to specify a default URL template fallback.
  * Added `sites_cache_size` configuration to control cache capacity.

* **Improvements**
  * Stronger site ID validation to gracefully skip invalid requests.
  * Cache sizing adjusted to better handle varying sitemap lengths for more reliable caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->